### PR TITLE
Smooth UI to --log2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,41 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* 
+
+### Fixed
+
+* 
+
+### Changed
+
+* 
+---
+
+## 1.5.0
+
+### Added
+
 * Unofficial support for different alphabets
 * Additional log transformation option
 
 ### Fixed
 
 * Length normalization divisor (length to [length -k +1])
+  * Includes a small fix to the length normalization step of the core *k*-mer counting code. In v1.4.2, *k*-mer counts were normalized to the number of basepairs in each input sequence. In v1.4.3, *k*-mer counts are normalized to the number of *k*-mers in each input sequence ([length_of_sequence] -[*k*-mer_length]+1). This is a minor change for correctness that should not meaningfully affect results.
+
 
 ### Changed
 
 * Behavior of --log2 argument
+  * Includes a redesigned flag to indicate the method of *k*-mer standardization, and an additional option for *k*-mer standardization: --log2 [1,2,3] or -l [1,2,3]. These options correspond to log-transforming pre-standardization, post-standardization, or no log-transform,
+respectively. 
+  * `--log2 post` (Default standardization method). This is the same default standardization method used in SEEKR v1.4.2. For a given set of sequences, *k*-mers are counted, then length normalized (counts per kb of sequence), then z-scores for each *k*-mer are calculated, and then these z-scores are log2-tranformed. See [PMID 31097619](https://pubmed.ncbi.nlm.nih.gov/31097619/) for examples and an in-depth description of the rationale for using log2-transformed z-scores as a default.
+  * `--log2 none` is the same as the no-log transformation option (-nl) of seekr v1.4.2. Here, after *k*-mers are counted and length-normalized, z-scores are calculated and used without any transformation. This was the approached used in our original SEEKR publication ([PMID 30224646](https://pubmed.ncbi.nlm.nih.gov/30224646/)).
+  * `--log2 pre` is the additional/new option for standardization. In this approach, *k*-mers are counted across a set of sequences and then length normalized (counts per kb of sequence). For each *k*-mer that has a zero-count value in each sequence, a pseudo-count of 1 is added; this allows the *k*-mer count values to be log2 transformed. Z-scores are calculated after log2-transformation of *k*-mer counts, and these z-scores can then be used directly for comparisons. In effect, this standardization method is not much different from the default option of --log2 2 (users can compare for themselves). It is, however, a slightly cleaner heuristic. In the time since our original two publications using seekr, we have noted that *k*-mer counts in the mouse and human transcriptomes tend to follow a log-normal distribution; thus, we currently favor this method of standardization. 
+* Includes small updates to “notes” and “Help” sections of README.md
+
+
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Want to make changes to seekr?
+
+A great place to start is by adding more documentation to this file. 
+It's a little underwhelming at the moment.
+
+## Running tests
+
+Install pytest with `pip install pytest`. 
+Run from the repo home directory:
+
+```
+pytest
+```
+
+Also make sure you can successfully execute `seekr/tests/integration.sh`.
+This is always worth checking, but doubly so if you're messing with integration code.
+The unit tests don't fully cover the interfaces.
+
+## Pushing changes
+
+If you're ready to push changes, please ensure you've commited them to a non-master branch.
+Push the branch to the remote repository, and submit a [PR](https://github.com/CalabreseLab/seekr/pulls).
+Reviews are good for everyone. :)
+
+## Publishing changes
+
+You'll need `twine` installed via `pip install twine`.
+ 
+Once changes have been approved and are in master
+
+1. Bump the version in `__version__.py`
+2. TODO

--- a/README.md
+++ b/README.md
@@ -79,24 +79,6 @@ Fasta files can be found [here](https://www.gencodegenes.org/releases/current.ht
   * In the examples below we'll generically refer to `gencode.fa`.
     Any sufficiently large fasta file can be used, as needed.
  
-Some general advice for thinking about how to use SEEKR. One challenge that we continually face in the lab is there are few ground truths in the lncRNA field and thus it is often unclear how to decide on the best parameters for sequence comparisons using SEEKR. Below are two points that may be useful – these are also discussed in the conclusions of [PMID 31097619](https://pubmed.ncbi.nlm.nih.gov/31097619/):
-
-* On the selection of a set of sequences to use for the calculation of standardization vectors: In our experience, one of the most useful features of SEEKR is that it provides a metric of relative similarity. Consider two lncRNAs, lncRNA-X, which is from mouse, and lncRNA-Y, which is from human. One way to compare these two lncRNAs using SEEKR would be to calculate their *k*-mer profiles and compare these profiles in relation to all known mouse lncRNAs. To do this, one would first use all mouse lncRNAs as an input for the "seekr_norm_vectors" script, to determine the mean and standard deviation of counts for all *k*-mers in all mouse lncRNAs. Then, users would take those standardization vectors along with the sequences of lncRNA-X and lncRNA-Y and use them in the “kmer_counts” script to calculate *k*-mer profiles of lncRNA-X and lncRNA-Y in relation to all mouse lncRNAs. Finally, users would employ the “seekr_pearson” script to determine how similar lncRNA-X and lncRNA-Y were to each other relative to all other mouse lncRNAs. The point here is that the set of sequences used to calculate standardization vectors is a key variable – perhaps analogous to a reference gene in a quantitative PCR experiment or a loading control in a western blot. Users should think through what comparison they are interested in performing and choose their set of standardization sequences accordingly. In the example above, where all mouse lncRNAs were used for standardization, users might discover that “At the level of *k*-mers, lncRNA-X is more similar to lncRNA-Y than it is similar to 99% of other mouse lncRNAs”. But changing the set of sequences for standardization can change the question being asked. For example, users might be interested in comparing lncRNA-X and lncRNA-Y relative to all known human enhancer RNAs (eRNAs). Here, using all human eRNAs as the standardization set, users might make an additional insightful discovery, perhaps: “At the level of *k*-mers, lncRNA-X is no more similar to lncRNA-Y than it is similar to the average human eRNA”. Relatedly, when users are comparing two large groups of sequences (let us call these “set A” and “set B”), we again recommend thinking about what set of reference sequences would be best for standardization. In most cases, users will probably want to use the same set of reference sequences to standardize *k*-mer counts in set A and in set B.  Perhaps set A and set B should again be standardized relative to all mouse lncRNAs; or, both set A and set B be should be standardized relative to the sequences in set B. But standardizing set A relative to itself, then standardizing set B relative to itself, then using “seekr_pearson” to compare the two sets of sequences might yield a non-sensical comparison.
-*	On the selection of *k*-mer length: In our experience, the most robust biological trends have been relatively insensitive to the length of *k*-mer used in SEEKR. Still, when deciding on a length of k to use for comparisons, we recommend using a *k*-mer length for which 4^k is similar to the length of the average feature or key feature that is being compared. The reason for this is that as the length of k increases, so does the number of zero values for *k*-mer counts in a given sequence. For example, there are 16384 possible 7-mers. If users were interested in finding lncRNAs that are similar to lncRNA-X, which is 500 nucleotides long, a *k*-mer length of 7 would not be ideal, because the vector of 7-mer counts that corresponds to lncRNA-X would be dominated by zero values. In this example, unless users had a specific rationale for searching 7-mers, a *k*-mer length of 4 (256 possible *k*-mers) or 5 (1024 possible *k*-mers) would provide the basis for a stronger comparison.
-
-
-### Help
-
-Please also see [the pre-print](https://github.com/CalabreseLab/seekr/blob/logchanges/methods_mol_bio_seekr-v20.pdf) to a methods paper we wrote last year. This paper was originally scheduled to appear in Methods in Molecular Biology in 2020 but its publication date may be delayed. 
-
-If you have questions about how you can use seekr in your own research, please send an email to jmcalabr@med.unc.edu
-
-For full documentation, type:
-
-```
-$ seekr_kmer_counts
-```
-
 Here are some examples if you just want to get going.
 
 ### Command line examples
@@ -158,12 +140,15 @@ $ cat out_counts.csv
 You can also see the output of this command
 [here](https://github.com/CalabreseLab/seekr/seekr/tests/data/example_2mers.csv).
 
-Three options are available for log transformation, using the --log2 flag. Pass `--log2 1` for log transformation of length normalized *k*-mer counts, with a +1 pseudo-count, pass `--log2 2` for log transformation of z-scores following count standardization (default), and pass `--log2 3` for no log transformation.
+Three options are available for log transformation, using the `--log2` flag. 
+Pass `--log2 pre` for log transformation of length normalized *k*-mer counts, with a +1 pseudo-count, 
+pass `--log2 post` for log transformation of z-scores following count standardization (this is the default), 
+and pass `--log2 none` for no log transformation.
 
-If we want to avoid normalization, we can produce *k*-mer counts per kb by setting the `--log2 3`, `--uncentered` and `--unstandardized` flags:
+If we want to avoid normalization, we can produce *k*-mer counts per kb by setting the `--log2 non`, `--uncentered` and `--unstandardized` flags:
 
 ```
-$ seekr_kmer_counts example.fa -o out_counts.csv -k 2 --log2 3 -uc -us
+$ seekr_kmer_counts example.fa -o out_counts.csv -k 2 --log2 none -uc -us
 ```
 
 Similarly, if we want a more compact, efficient numpy file,
@@ -211,7 +196,8 @@ standard deviation vectors produced from a larger set of transcripts.
 We can produce these vectors once, then use them on multiple smaller sets
 of RNAs of interest. To produce the vectors, run:
 
-**Note** If --log2 1 is passed in *seekr_kmer_counts*, then the -cl flag must be passed to *seekr_norm_vectors*. This is so that the log-transformed *k*-mer counts are standardized against reference *k*-mer counts that are also log transformed. 
+**Note:** If `--log2 post` is passed in *seekr_kmer_counts*, then the -cl flag must be passed to *seekr_norm_vectors*. 
+This is so that the log-transformed *k*-mer counts are standardized against reference *k*-mer counts that are also log transformed. 
 
 ```
 $ seekr_norm_vectors gencode.fa
@@ -393,10 +379,56 @@ Once this has been saved, the first portion of the code doesn't need to be run a
 * `xist_vs_lncs_{k}mers.npy`: Pearson's r values for all pairwise comparisons between Xist and the other lncRNAs.
 * `xist_vs_lncs_{k}mers.csv`: Labeled, plain text version of pairwise comparisons.
 
-## Issues
+## Additional considerations
+
+This section is a "not-so-quickstart", providing more complete views on selection of input data and parameter selection.
+
+Some general advice for thinking about how to use SEEKR. 
+One challenge that we continually face in the lab is there are few ground truths in the lncRNA field and thus it is often unclear how to decide on the best parameters for sequence comparisons using SEEKR. 
+Below are some points that may be useful – these are also discussed in the conclusions of [PMID 31097619](https://pubmed.ncbi.nlm.nih.gov/31097619/)
+
+### Selection of a set of sequences to use for the calculation of standardization vectors
+
+In our experience, one of the most useful features of SEEKR is that it provides a metric of relative similarity. 
+Consider two lncRNAs, lncRNA-X, which is from mouse, and lncRNA-Y, which is from human. 
+One way to compare these two lncRNAs using SEEKR would be to calculate their *k*-mer profiles and compare these profiles in relation to all known mouse lncRNAs. 
+To do this, one would first use all mouse lncRNAs as an input for the "seekr_norm_vectors" script, to determine the mean and standard deviation of counts for all *k*-mers in all mouse lncRNAs. 
+Then, users would take those standardization vectors along with the sequences of lncRNA-X and lncRNA-Y and use them in the “kmer_counts” script to calculate *k*-mer profiles of lncRNA-X and lncRNA-Y in relation to all mouse lncRNAs. 
+Finally, users would employ the “seekr_pearson” script to determine how similar lncRNA-X and lncRNA-Y were to each other relative to all other mouse lncRNAs. 
+The point here is that the set of sequences used to calculate standardization vectors is a key variable – perhaps analogous to a reference gene in a quantitative PCR experiment or a loading control in a western blot. 
+Users should think through what comparison they are interested in performing and choose their set of standardization sequences accordingly. 
+In the example above, where all mouse lncRNAs were used for standardization, users might discover that “At the level of *k*-mers, lncRNA-X is more similar to lncRNA-Y than it is similar to 99% of other mouse lncRNAs”. 
+But changing the set of sequences for standardization can change the question being asked. 
+For example, users might be interested in comparing lncRNA-X and lncRNA-Y relative to all known human enhancer RNAs (eRNAs). 
+Here, using all human eRNAs as the standardization set, users might make an additional insightful discovery, perhaps: “At the level of *k*-mers, lncRNA-X is no more similar to lncRNA-Y than it is similar to the average human eRNA”. 
+Relatedly, when users are comparing two large groups of sequences (let us call these “set A” and “set B”), we again recommend thinking about what set of reference sequences would be best for standardization. 
+In most cases, users will probably want to use the same set of reference sequences to standardize *k*-mer counts in set A and in set B.  
+Perhaps set A and set B should again be standardized relative to all mouse lncRNAs; or, both set A and set B be should be standardized relative to the sequences in set B. 
+But standardizing set A relative to itself, then standardizing set B relative to itself, then using “seekr_pearson” to compare the two sets of sequences might yield a non-sensical comparison.
+
+### Selection of *k*-mer length
+
+In our experience, the most robust biological trends have been relatively insensitive to the length of *k*-mer used in SEEKR. 
+Still, when deciding on a length of k to use for comparisons, we recommend using a *k*-mer length for which 4^k is similar to the length of the average feature or key feature that is being compared. 
+The reason for this is that as the length of k increases, so does the number of zero values for *k*-mer counts in a given sequence. 
+For example, there are 16384 possible 7-mers. 
+If users were interested in finding lncRNAs that are similar to lncRNA-X, which is 500 nucleotides long, a *k*-mer length of 7 would not be ideal, because the vector of 7-mer counts that corresponds to lncRNA-X would be dominated by zero values. 
+In this example, unless users had a specific rationale for searching 7-mers, a *k*-mer length of 4 (256 possible *k*-mers) or 5 (1024 possible *k*-mers) would provide the basis for a stronger comparison.
+ 
+## Issues and Help 
+
+If you have questions about how you can use seekr in your own research, please send an email to jmcalabr@med.unc.edu
+
+For full documentation, run:
+
+```
+$ seekr
+```
 
 Any suggestions, questions, or problems can be directed to our
 [GitHub Issues page](https://github.com/CalabreseLab/seekr/issues).
+
+Please also see [the pre-print](https://github.com/CalabreseLab/seekr/blob/logchanges/methods_mol_bio_seekr-v20.pdf) to a methods paper we wrote last year. This paper was originally scheduled to appear in Methods in Molecular Biology in 2020 but its publication date may be delayed.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -7,25 +7,6 @@ Find communities of nucleotide sequences based on *k*-mer frequencies.
 
 A web portal is available at [seekr.org](http://seekr.org).
 
-## Updates
-
-7/15/20, version 1.4.3
-
-
-Includes a redesigned flag to indicate the method of *k*-mer standardization, and an additional option for *k*-mer standardization: --log2 [1,2,3] or -l [1,2,3]. These options correspond to log-transforming pre-standardization, post-standardization, or no log-transform,
-respectively. 
-
-1.	Default standardization method is --log2 2. This is the same default standardization method used in SEEKR v1.4.2. For a given set of sequences, *k*-mers are counted, then length normalized (counts per kb of sequence), then z-scores for each *k*-mer are calculated, and then these z-scores are log2-tranformed. See [PMID 31097619](https://pubmed.ncbi.nlm.nih.gov/31097619/) for examples and an in-depth description of the rationale for using log2-transformed z-scores as a default.
-
-2.	--log2 3 is the same as the no-log transformation option (-nl) of seekr v1.4.2. Here, after *k*-mers are counted and length-normalized, z-scores are calculated and used without any transformation. This was the approached used in our original SEEKR publication ([PMID 30224646](https://pubmed.ncbi.nlm.nih.gov/30224646/)).
-
-3. --log2 1 is the additional/new option for standardization. In this approach, *k*-mers are counted across a set of sequences and then length normalized (counts per kb of sequence). For each *k*-mer that has a zero-count value in each sequence, a pseudo-count of 1 is added; this allows the *k*-mer count values to be log2 transformed. Z-scores are calculated after log2-transformation of *k*-mer counts, and these z-scores can then be used directly for comparisons. In effect, this standardization method is not much different from the default option of --log2 2 (users can compare for themselves). It is, however, a slightly cleaner heuristic. In the time since our original two publications using seekr, we have noted that *k*-mer counts in the mouse and human transcriptomes tend to follow a log-normal distribution; thus, we currently favor this method of standardization. 
-
-4. Includes small updates to “notes” and “Help” sections of README.md
-
-5. Includes a small fix to the length normalization step of the core *k*-mer counting code. In v1.4.2, *k*-mer counts were normalized to the number of basepairs in each input sequence. In v1.4.3, *k*-mer counts are normalized to the number of *k*-mers in each input sequence ([length_of_sequence] -[*k*-mer_length]+1). This is a minor change for correctness that should not meaningfully affect results.
-
-
 ## Installation
 
  To use this library, you have to have >Python3.6 on your computer.

--- a/seekr/__version__.py
+++ b/seekr/__version__.py
@@ -1,7 +1,7 @@
 __title__ = 'seekr'
 __description__ = 'Count small kmer frequencies in nucleotide sequences.'
 __url__ = 'https://github.com/CalabreseLab/seekr'
-__version__ = '1.4.2'
+__version__ = '1.5.0'
 __author__ = 'Jessime Kirk'
 __author_email__ = 'jessime.kirk@gmail.com'
 __license__ = 'MIT'

--- a/seekr/kmer_counts.py
+++ b/seekr/kmer_counts.py
@@ -33,12 +33,16 @@ Any issues can be reported to https://github.com/CalabreseLab
 
 import numpy as np
 
+from enum import Enum
 from collections import defaultdict
 from itertools import product
 from pandas import DataFrame
 
 from seekr.my_tqdm import my_tqdm
 from seekr.fasta_reader import Reader
+
+
+Log2 = Enum('Log2', ('pre', 'post', 'none'))
 
 
 class BasicCounter:
@@ -60,9 +64,8 @@ class BasicCounter:
     std: bool, np.array, str (default=True)
         Set the std. dev. to 1 for each kmer/column of the count matrix.
         If str, provide path to a previously calculated std array.
-    log2: int (default=2)
-        Pass 1,2 or 3 for pre-standardization log transform, post-standardization log transform, 
-        or no log-transform respectively. 
+    log2: Log2 (default=Log2.post)
+        Log2 transformation can occur pre- or post-standardization, or not at all.
     leave: bool (default=True)
         Set to False if get_counts is used within another tqdm loop
     silent: bool (default=False)
@@ -83,7 +86,7 @@ class BasicCounter:
     """
 
     def __init__(self, infasta=None, outfile=None, k=6,
-                 binary=True, mean=True, std=True, log2=2,
+                 binary=True, mean=True, std=True, log2=Log2.post,
                  leave=True, silent=False, label=False, alphabet='AGTC'):
         self.infasta = infasta
         self.seqs = None
@@ -114,9 +117,8 @@ class BasicCounter:
                        'or use raw counts by setting std=False.')
                 raise ValueError(err)
 
-        if self.log2 not in [1,2,3]:
-            err=('Please provide a value of 1,2, or 3 for the log2 argument')
-            raise ValueError(err)
+        if not isinstance(self.log2, Log2):
+            raise TypeError(f'log2 must be one of {list(Log2)}')
 
     def occurrences(self, row, seq):
         """Counts kmers on a per kilobase scale"""
@@ -175,14 +177,14 @@ class BasicCounter:
 
         for i, seq in enumerate(seqs):
             self.counts[i] = self.occurrences(self.counts[i], seq)
-        if self.log2 == 1: 
+        if self.log2 == Log2.pre:
             self.log2_norm()
         if self.mean is not False:
             self.center()
         if self.std is not False:
             self.standardize()
-        if self.log2 == 2:
-            self.counts+=np.abs(np.min(self.counts)) 
+        if self.log2 == Log2.post:
+            self.counts += np.abs(np.min(self.counts))
             self.log2_norm()
 
     def save(self, names=None):

--- a/seekr/pearson.py
+++ b/seekr/pearson.py
@@ -41,7 +41,7 @@ except ImportError:
 
 from seekr.my_tqdm import my_tqdm
 from seekr.fasta_reader import Reader
-from seekr.kmer_counts import BasicCounter
+from seekr.kmer_counts import BasicCounter, Log2
 from seekr.utils import get_adj
 
 
@@ -136,9 +136,8 @@ class DomainPearson:
         Set the std. dev. to 1 for each kmer/column of the count matrix.
         If str, provide path to a previously calculated std array.
         Can be produced by `seekr_norm_vectors`.
-    log2: int (default=2)
-        Pass 1,2, or 3 for pre-standardization log-transform, post-standardization log transform, or
-        no log transform, respectively. 
+    log2: Log2 (default=Log2.post)
+        Log2 transformation can occur pre- or post-standardization, or not at all.
     k: int (default=6)
         Size of kmer to be counted.
     window: int (default=1000)
@@ -166,7 +165,7 @@ class DomainPearson:
     """
 
     def __init__(self, query_path=None, target_path=None, reference_path=None, r_values_path=None,
-                 percentiles_path=None, mean=True, std=True, log2=2,
+                 percentiles_path=None, mean=True, std=True, log2=Log2.post,
                  k=6, window=1000, slide=100):
         self.query_path = query_path
         self.target_path = target_path

--- a/seekr/tests/test_console_scripts.py
+++ b/seekr/tests/test_console_scripts.py
@@ -10,6 +10,7 @@ import pkg_resources
 import pytest
 
 from seekr import console_scripts
+from seekr.kmer_counts import Log2
 from seekr import graph
 
 class TestConsoleScripts:
@@ -39,7 +40,7 @@ class TestConsoleScripts:
                                          binary=True,
                                          centered=True,
                                          standardized=True,
-                                         log2=2,
+                                         log2=Log2.post.name,
                                          remove_labels=True,
                                          mean_vector=None,
                                          std_vector=None,
@@ -60,7 +61,7 @@ class TestConsoleScripts:
                                          binary=False,
                                          centered=False,
                                          standardized=False,
-                                         log2=3,
+                                         log2=Log2.none.name,
                                          remove_labels=True,
                                          mean_vector=None,
                                          std_vector=None,
@@ -86,7 +87,7 @@ class TestConsoleScripts:
                                          binary=True,
                                          centered=False,
                                          standardized=False,
-                                         log2=2,
+                                         log2=Log2.post.name,
                                          remove_labels=True,
                                          mean_vector=mean_vector,
                                          std_vector=std_vector,
@@ -105,7 +106,7 @@ class TestConsoleScripts:
         console_scripts._run_norm_vectors(fasta=infasta,
                                           mean_vector=mean,
                                           std_vector=std,
-                                          count_log2=False,
+                                          log2=Log2.none.name,
                                           kmer=2)
         mean = np.load(mean)
         std = np.load(std)

--- a/seekr/tests/test_kmer_counts.py
+++ b/seekr/tests/test_kmer_counts.py
@@ -10,7 +10,7 @@ class TestBasicCounter:
         infasta = pkg_resources.resource_filename('seekr', infasta)
         counter = kmer_counts.BasicCounter(infasta=infasta,
                                            silent=True,
-                                           log2=2,
+                                           log2=kmer_counts.Log2.post,
                                            **kwargs)
         return counter
 


### PR DESCRIPTION
From an end user's perspective, the only thing I've really done here is make the parameter options for `--log2` be one of `['pre', 'post', 'none']`

I also fooled around with the documentation a little, but nothing substantial. @spragud2, I didn't delete anything you wrote, just moved it around.